### PR TITLE
Fix .cpanel.yml deploy paths to copy from app/ after reorganise

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -2,7 +2,7 @@
 deployment:
   tasks:
     - export DEPLOYPATH=/home/activepe/public_html/
-    - export REPO=/home/activepe/repositories/Activepetz/
+    - export REPO=/home/activepe/repositories/Activepetz/app/
     - /bin/cp -R "$REPO/js" $DEPLOYPATH
     - /bin/cp -R "$REPO/css" $DEPLOYPATH
     - /bin/cp -R "$REPO/media" $DEPLOYPATH


### PR DESCRIPTION
Deploy tasks still referenced repo-root paths for js/css/media/html, which no longer exist there since files moved to app/.